### PR TITLE
Don't skip node 6 LTS for Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '4'
+- '6'
 - stable
 sudo: false
 git:


### PR DESCRIPTION
`'stable'` currently resolves to node `7`.