### PR TITLE
Replace pybabel lib by babel-gettext-plugin

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 bin/extract_messages
+bin/babel-preset-gettext.json
 **/*.js.flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
   - Clean dependencies and improve installation part of the README.
+  - Replace `pybabel` extraction lib by `babel-gettext-plugin`.
 
 ## [1.0.0-alpha] - 2016-11-17
 

--- a/README.md
+++ b/README.md
@@ -132,31 +132,18 @@ JavaScript, it is your responsibility to pass it to the extract script._
 
 ## 3. Create language files
 
-**Prerequisite:**
+This library uses babel and the plugin
+[babel-gettext-plugin](https://www.npmjs.com/package/babel-gettext-plugin) to extract your
+internationalized strings.
 
-You need [the extracting tool `pybabel`](http://babel.pocoo.org/en/latest/) (launch extract_messages for installation help), you need `babel-cli` and the preset used by your app and also `po2json`.
+> In case you created your app with create-react-app you have to declare the babel preset you need
+to build your application, for example:
 
-For example, first create the file `pybabel.cfg` with the following content:
-
-```
-[javascript: **.js]
-encoding = utf-8
-extract_messages = __
-```
-
-Then if you created your app with create-react-app and using a debian like OS, you can do the following setup:
-
-```bash
-# pybabel installation
-sudo apt-get install python-pybabel
-# force dependencies (OK we need to make this easier)
-npm i babel-cli babel-preset-react-app po2json
-# force the preset for babel
-cat <<EOF > .babelrc
+```json
+// file:.babelrc
 {
-  "presets": ["react-app"]
+  "presets": ["react"]
 }
-END
 ```
 
 ### Message files
@@ -290,10 +277,7 @@ Else you can start with [CONTRIBUTING.md](CONTRIBUTING.md).
 
 * Document `Pricing` features
 * Add formatCurrency component
-* Extract babeljs compilation process from extract_messages script (CRA compatible)
 * Improve doc on how to load translations (at least give an example)
 * Link translator options to related libs
-* Remove required pybabel.cfg
 * Allow user to init a logger for missing translations and use `warning` as fallback
 * Fix or change build process in `bin/merge_catalogs` which looks for legacy gandi's catalogs
-* Replace pybabel by a npm script (eg. https://www.npmjs.com/package/babel-gettext-extractor)

--- a/bin/babel-preset-gettext.json
+++ b/bin/babel-preset-gettext.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["babel-gettext-plugin", {
+      "functionNames": {
+        "__": ["msgid"]
+      },
+      "fileName": "tmp-react-translate/extracted.po"
+    }]
+  ]
+}

--- a/bin/extract_messages
+++ b/bin/extract_messages
@@ -16,38 +16,29 @@ if [[ $# -eq 1 ]] ; then
     exit 1
 fi
 
-hash pybabel 2>/dev/null || { echo >&2 "Please install pybabel and try again \
-(\`apt install python-pybabel\` or \`pip install babel\`)."; exit 1; }
+set -e
 
 CURRENT_DIR="$(pwd)"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TMP_DIRECTORY=tmp-react-translate
 APP_DIR=$1
 NAMESPACE=$2
+PO_FILE=$TMP_DIRECTORY/extracted.po
 FILENAME=locales/template/${NAMESPACE}.json
 
-echo "# Extracting to the '${NAMESPACE}' namespace from ${APP_DIR}"
-TMP_BABEL_DIR=$CURRENT_DIR/tmp_babel_compiled
-mkdir -p $TMP_BABEL_DIR
-POT_FILE=${TMP_BABEL_DIR}/locales/translations.pot
-mkdir -p $TMP_BABEL_DIR/locales/
+mkdir -p $TMP_DIRECTORY/
 mkdir -p $CURRENT_DIR/locales/template/
 
-set -e
-# Transpile ES6 to ES5 js, as pybabel chokes on some JSX constructs.
-node_modules/.bin/babel $APP_DIR --out-dir $TMP_BABEL_DIR > /dev/null
-
-# Don't confuse babeljs with pybabel. ;)
-pybabel extract -F pybabel.cfg --omit-header --sort-output \
-    -k __:1 --no-default-keywords -o $POT_FILE $TMP_BABEL_DIR  &> /dev/null
-node_modules/.bin/po2json $POT_FILE $FILENAME -f mf --pretty --fallback-to-msgid
+node_modules/.bin/babel --presets $SCRIPT_DIR/babel-preset-gettext.json $APP_DIR  > /dev/null
+node_modules/.bin/po2json $PO_FILE $FILENAME -f mf --pretty --fallback-to-msgid
 
 echo -e "  \e[32mSuccessfully extracted messages to ${FILENAME}\e[0m"
 
 # clean
-rm $POT_FILE
-rm -r $TMP_BABEL_DIR
+rm -r $TMP_DIRECTORY
 
 # merge external libs messages
-node_modules/.bin/merge_catalogs $2
+node_modules/.bin/merge_catalogs $NAMESPACE
 
 # rewrite plurals
 node_modules/.bin/create_counterpart_plurals

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "files": [
     "bin",
     "dist",
+    "doc",
     "tests",
     "CHANGELOG.md",
+    "LICENSE",
     "README.md"
   ],
   "scripts": {
@@ -40,7 +42,7 @@
   "bugs": {
     "url": "https://github.com/Gandi/react-translate/issues"
   },
-  "homepage": "",
+  "homepage": "https://github.com/Gandi/react-translate",
   "devDependencies": {
     "@gandi/babel-preset-gandi": "^1.0.0",
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
simplify usage of react-translate by removing python lib dependency (and pybabel.conf file actually useless for the user etc.)

+ remove useless requirements from doc (preset, po2json, ...)