### PR TITLE
Remove Lodash dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## [Unreleased]
 
 ### Added
-
   - Create a launcher for extract_messages, update_catalog and other scripts.
+  - Sample app.
 
 ### Changed
-
   - Clean dependencies and improve installation part of the README.
   - Replace `pybabel` extraction lib by `babel-gettext-plugin`.
+  - Remove lodash dependency.
 
 ## [1.0.0-alpha] - 2016-11-17
 

--- a/bin/clean_catalog
+++ b/bin/clean_catalog
@@ -13,7 +13,6 @@
  * could be used in weblate to suggest translations
  */
 
-var _ = require('lodash');
 var fs = require('fs');
 var glob = require('glob');
 var helpers = require('./helpers');
@@ -34,7 +33,7 @@ glob('locales/*/*.json', {}, function (er, files) {
     return true;
   }
 
-  return _.each(files, function (path) {
+  return files.forEach(function (path) {
     if (path.match(/template\/[^/]+\.json$/)) {
       return true;
     }
@@ -49,12 +48,13 @@ glob('locales/*/*.json', {}, function (er, files) {
         throw er_;
       }
 
-      _.each(sourceFiles, function (sourcePath) {
+      sourceFiles.forEach(function (sourcePath) {
         var sourceJson = JSON.parse(fs.readFileSync(sourcePath, 'utf-8'));
 
         // New translations should have an empty translation.
-        var newJson = _.mapValues(sourceJson, function (key) {
-          return oldJson[key];
+        var newJson = Object.assign({}, sourceJson);
+        Object.keys(sourceJson).forEach(function (key) {
+          newJson[key] = oldJson[sourceJson[key]];
         });
 
         var printableJson = JSON.stringify(helpers.sortObject(newJson), null, 4);

--- a/bin/create_catalog
+++ b/bin/create_catalog
@@ -14,7 +14,6 @@
  * with the new messages that were found.
  */
 
-var _ = require('lodash');
 var fs = require('fs');
 var glob = require('glob');
 var helpers = require('./helpers');
@@ -37,7 +36,7 @@ glob('locales/template/*.json', {}, function (er, files) {
     return true;
   }
 
-  return _.each(files, function (path, index) {
+  return files.forEach(function (path, index) {
     var newFiles = [];
 
     glob('locales/*', {}, function (erDirs, dirs) {
@@ -46,14 +45,14 @@ glob('locales/template/*.json', {}, function (er, files) {
         throw erDirs;
       }
 
-      _.each(dirs, function (dir) {
+      dirs.forEach(function (dir) {
         const lang = dir.replace('locales/', '');
         if (lang !== 'template') {
           newFiles.push(path.replace(/(.*)\/[\w_]+\/(.*)/, '$1/' + lang + '/$2'));
         }
       });
 
-      _.each(newFiles, function (newPath, indexLocales) {
+      newFiles.forEach(function (newPath, indexLocales) {
         if (index === files.length - 1 &&
             newFiles.length && indexLocales === newFiles.length - 1) {
           if (filesCreated === false) {
@@ -67,10 +66,11 @@ glob('locales/template/*.json', {}, function (er, files) {
         }
 
         var sourceJson = JSON.parse(fs.readFileSync(path, 'utf-8'));
-        sourceJson = _.mapValues(sourceJson, function () {
-          return '';
+
+        Object.keys(sourceJson).forEach(function (key) {
+          sourceJson[key] = '';
         });
-        var newJson = _.defaults({}, sourceJson);
+        var newJson = Object.assign({}, sourceJson);
 
         var printableJson = JSON.stringify(newJson, null, 4);
 

--- a/bin/create_counterpart_plurals
+++ b/bin/create_counterpart_plurals
@@ -11,7 +11,6 @@
  * of counterpart's plurals syntax.
  */
 
-var _ = require('lodash');
 var fs = require('fs');
 var glob = require('glob');
 var helpers = require('./helpers');
@@ -33,12 +32,13 @@ glob('locales/template/*.json', {}, function (er, files) {
     return true;
   }
 
-  return _.each(files, function (path) {
+  return files.forEach(function (path) {
     helpers.log('  ' + path);
     var sourceJson = JSON.parse(fs.readFileSync(path, 'utf-8'));
 
-    var newJson = sourceJson;
-    _.forOwn(sourceJson, function (value, key) {
+    var newJson = Object.assign({}, sourceJson);
+
+    Object.keys(sourceJson).forEach(function (key) {
       if (!key.match(/\|\w+$/) && key.match(/%\(count\)[d|s]/)) {
         newJson[key + '|zero'] = key + '|zero';
         newJson[key + '|one'] = key + '|one';

--- a/bin/merge_catalogs
+++ b/bin/merge_catalogs
@@ -10,7 +10,6 @@
  * to merge external libraries messages with passed apps messages.
  */
 
-var _ = require('lodash');
 var fs = require('fs');
 var glob = require('glob');
 
@@ -36,7 +35,7 @@ glob('node_modules/gandi.*/dist/locales/template/*.json', {}, function (er, file
     return true;
   }
 
-  return _.each(files, function (path) {
+  return files.forEach(function (path) {
     helpers.log('  ' + path);
     var partialJson = JSON.parse(fs.readFileSync(path, 'utf-8'));
 
@@ -49,7 +48,7 @@ glob('node_modules/gandi.*/dist/locales/template/*.json', {}, function (er, file
       helpers.warn(destPath + ' doesn\'t exist yet, will create it.');
     }
 
-    var newJson = _.defaults(sourceJson, partialJson);
+    var newJson = Object.assign({}, partialJson, sourceJson);
 
     var printableJson = JSON.stringify(helpers.sortObject(newJson), null, 4);
 

--- a/bin/update_catalog
+++ b/bin/update_catalog
@@ -12,7 +12,6 @@
  * ones with the new messages that were found.
  */
 
-var _ = require('lodash');
 var fs = require('fs');
 var glob = require('glob');
 var helpers = require('./helpers');
@@ -34,7 +33,7 @@ glob('locales/*/*.json', {}, function (er, files) {
     return true;
   }
 
-  return _.each(files, function (file) {
+  return files.forEach(function (file) {
     var path = file;
     if (path.match(/template\/[^/]+\.json$/)) {
       return true;
@@ -50,14 +49,15 @@ glob('locales/*/*.json', {}, function (er, files) {
         throw er_;
       }
 
-      _.each(sourceFiles, function (sourcePath) {
+      sourceFiles.forEach(function (sourcePath) {
         var sourceJson = JSON.parse(fs.readFileSync(sourcePath, 'utf-8'));
 
         // New translations should have an empty translation.
-        sourceJson = _.mapValues(sourceJson, function () {
-          return '';
+        Object.keys(sourceJson).forEach(function (key) {
+          sourceJson[key] = '';
         });
-        var newJson = _.defaults(oldJson, sourceJson);
+
+        var newJson = Object.assign({}, sourceJson, oldJson);
 
         var printableJson = JSON.stringify(helpers.sortObject(newJson), null, 4);
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "glob": "^7.0.5",
     "hoist-non-react-statics": "^1.2.0",
     "intl": "^1.2.5",
-    "lodash": "^4.17.1",
     "moment": "^2.15.1",
     "po2json": "^0.4.1",
     "shallowequal": "^0.2.2",

--- a/src/tools/enhanceTranslate.js
+++ b/src/tools/enhanceTranslate.js
@@ -1,6 +1,28 @@
-import escape from 'lodash/escape';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
+
+// Used to map characters to HTML entities.
+const htmlEscapes = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+const accessor = object => key => object[key];
+const unescapeHTMLCharReplacer = accessor(htmlEscapes);
+
+const reUnescapedHtml = /[&<>"']/g;
+const reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
+
+const escape = (string) => {
+  if (string && reHasUnescapedHtml.test(string)) {
+    return string.replace(reUnescapedHtml, unescapeHTMLCharReplacer);
+  }
+
+  return string;
+};
 
 const componentToString = (key, elt) => {
   if (!React.isValidElement(elt)) return elt;

--- a/src/tools/negociateLocale.js
+++ b/src/tools/negociateLocale.js
@@ -1,5 +1,20 @@
-import _ from 'lodash';
-
+/**
+ * Simple truthy-only, unique intersection function of two arrays.
+ *
+ * @param Array   array1
+ * @param Array   array2
+ *
+ * @return Array
+ */
+function simpleIntersection(array1, array2) {
+  return array1
+    // Remove falsy elements
+    .filter(el => el)
+    // Match elements belonging in the two arrays
+    .filter(el => array2.indexOf(el) !== -1)
+    // Remove duplicates
+    .filter((el, idx, arr) => arr.indexOf(el) === idx);
+}
 
 /**
  * Returns the best match for the user's locale.
@@ -15,8 +30,9 @@ const negociateLocale = (
   availableLocales,
   defaultLocale
 ) => {
-  const validLanguages = _.intersection(
-    preferedLocales.filter(x => x),
+  const validLanguages =
+  simpleIntersection(
+    preferedLocales,
     availableLocales
   );
 


### PR DESCRIPTION
Lodash is a great tool, but I feel like it is a burden for the users to have it fully included as a -heavy- dependency.

Lodash was mainly used in ./bin/ files to iterate over arrays, mapping values,
we can use plain old ES5 and a bit of ES6 (Object.assign - available in Node.js starting from 4.x)

Replaced usage of lodash.escape function by an equivalent helper function

Related to #6 and #5 