### PR TITLE
Add missing `babel-gettext-plugin` and move po2json in peerDepencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+  - Add missing `babel-gettext-plugin` in peerDependencies and installation process
+  - move `po2json` to peerDependencies for consistency
+
 ## [1.0.0] - 2016-11-24
 ### Added
   - Create a launcher for extract_messages, update_catalog and other scripts.
@@ -19,15 +24,15 @@
   - Make the 'gandi' directory (in locales) before extraction.
 
 ### Changed
-  * Clean deps: colors, lodash, moment are now peer deps.
+  - Clean deps: colors, lodash, moment are now peer deps.
 
 ## 2016-10-25
 ### Added
-  * ability to render static components in translations variables.
+  - ability to render static components in translations variables.
 
 ## 2016-10-18
 ### Fixed
-  * Export localeSelector
+  - Export localeSelector
 
 ### Fixed
   - Deprecate action `selectLocale`.
@@ -69,7 +74,7 @@
 
 ## 2016-09-21
 ### Fixed
-  * Add propsNamespace attribute in stubWithTranslator test helper
+  - Add propsNamespace attribute in stubWithTranslator test helper
 
 ## 2016-09-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -33,16 +33,12 @@ scripts:
 }
 ```
 
-Make sure you have `babel-cli` in your dependencies (it's up to you to select the version saved in
-your project):
+Extraction script requires `babel-cli`, `babel-gettext-plugin` and `po2json` in your dependencies
+(it's up to you to select the version saved in your project):
 
 ```
-npm install babel-cli
+npm install --save-dev babel-cli babel-gettext-plugin po2json
 ```
-
-> Note for npm 2 users, you have to make sure po2json in the root `node_modules`, the same way as
-`babel-cli`
-
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -79,12 +79,13 @@
     "hoist-non-react-statics": "^1.2.0",
     "intl": "^1.2.5",
     "moment": "^2.15.1",
-    "po2json": "^0.4.1",
     "shallowequal": "^0.2.2",
     "warning": "^3.0.0"
   },
   "peerDependencies": {
     "babel-cli": "*",
+    "babel-gettext-plugin": "*",
+    "po2json": "^0.4.1",
     "react": "*",
     "react-dom": "*"
   }


### PR DESCRIPTION
- Add missing `babel-gettext-plugin` in peerDependencies and installation process
- move `po2json` to peerDependencies for consistency

And fix dashes in CHANGELOG for consistency