### PR TITLE
Use relative path to scripts in extract_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+  - Use relative path to scripts in `extract_messages` script.
+
 ## [1.0.1] - 2016-11-25
 
 ### Fixed
 
-  - Add missing `babel-gettext-plugin` in peerDependencies and installation process
-  - move `po2json` to peerDependencies for consistency
+  - Add missing `babel-gettext-plugin` in peerDependencies and installation process.
+  - move `po2json` to peerDependencies for consistency.
 
 ## [1.0.0] - 2016-11-24
 ### Added

--- a/bin/extract_messages
+++ b/bin/extract_messages
@@ -38,8 +38,8 @@ echo -e "  \e[32mSuccessfully extracted messages to ${FILENAME}\e[0m"
 rm -r $TMP_DIRECTORY
 
 # merge external libs messages
-node_modules/.bin/merge_catalogs $NAMESPACE
+$SCRIPT_DIR/merge_catalogs $NAMESPACE
 
 # rewrite plurals
-node_modules/.bin/create_counterpart_plurals
+$SCRIPT_DIR/create_counterpart_plurals
 set +e


### PR DESCRIPTION
the command extract_message finish in failure because of those two last commands (which are not supported since we don't expose it directly)

Bonus, it "fix" the format of the template.json file.